### PR TITLE
curl_close() deprecated

### DIFF
--- a/src/Mpay24Sdk.php
+++ b/src/Mpay24Sdk.php
@@ -709,7 +709,9 @@ class Mpay24Sdk
             }
 
             $this->response = curl_exec($ch);
-            curl_close($ch);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($ch);
+            }
 
         } catch (Exception $exception) {
             $message = $this->config->isTestSystem()


### PR DESCRIPTION
Since curl_close() has been deprecated since PHP 8.5, we need to check the PHP version. https://www.php.net/manual/en/function.curl-close.php